### PR TITLE
S() macro: enforce that all arguments are unique.

### DIFF
--- a/Headers/Macros.h
+++ b/Headers/Macros.h
@@ -163,19 +163,13 @@ while(enumerator != nil && (object = next ## object ## in ## enumerator(\
 #endif
 /** Shortcut macro to create a NSSet. Same as +[NSSet setWithObjects:]. */
 #define S(...) ({ \
-    id __objects[] = {__VA_ARGS__}; \
-    [NSSet setWithObjects: __objects \
-					count: (sizeof(__objects)/sizeof(id))]; \
-})
-/** Shortcut macro to create a NSSet. Same as S() but throws an exception if any arguments are equal to any others. */
-#define UNIQUESET(...) ({ \
 id __objects[] = {__VA_ARGS__}; \
 const NSUInteger __objects_count = (sizeof(__objects)/sizeof(id)); \
 NSSet *__result_set = [NSSet setWithObjects: __objects count: __objects_count]; \
 if ([__result_set count] != __objects_count) \
 { \
     NSArray *__objects_array = [NSArray arrayWithObjects: __objects count: __objects_count]; \
-    [NSException raise: NSInvalidArgumentException format: @"UNIQUESET() macro expects no duplicate arguments! Given: %@", __objects_array]; \
+    [NSException raise: NSInvalidArgumentException format: @"S() macro expects no duplicate arguments! Given: %@", __objects_array]; \
 } \
 __result_set; \
 })

--- a/Tests/TestMacros.m
+++ b/Tests/TestMacros.m
@@ -25,20 +25,8 @@
     UKRaisesException(S(nil));
     UKObjectsEqual([NSSet setWithObject: @"a"], S(@"a"));
     UKObjectsEqual([NSSet setWithArray: abArray], S(@"a", @"b"));
-    UKObjectsEqual([NSSet setWithObject: @"a"], S(@"a", @"a"));
+    UKRaisesException(S(@"a", @"a"));
 }
-
-- (void) testUNIQUESETMacro
-{
-    NSArray *abArray = [NSArray arrayWithObjects: @"a", @"b", nil];
-    
-    UKObjectsEqual([NSSet set], UNIQUESET());
-    UKRaisesException(UNIQUESET(nil));
-    UKObjectsEqual([NSSet setWithObject: @"a"], UNIQUESET(@"a"));
-    UKObjectsEqual([NSSet setWithArray: abArray], UNIQUESET(@"a", @"b"));
-    UKRaisesException(UNIQUESET(@"a", @"a"));
-}
-
 
 - (void) testAMacro
 {


### PR DESCRIPTION
This will throw an exception if you do S(@"a", @"a).

I don't know if we should change the semantics of S() like this, but I think this will help catch bugs. If you are using the S() macro with duplicates, it's probably an error.

With the latest commits I made to CO, the full CO test suite passes with this change.

I was trying to understand some tests, and it was very confusing to have S(a, b, c, d, e), but actually c, d, and e were equal, so the set was really just S(a, b, c).

